### PR TITLE
Line id reformation

### DIFF
--- a/irek-nazmiev/css/style.css
+++ b/irek-nazmiev/css/style.css
@@ -50,25 +50,8 @@ header {
      height: 100%;
 }
 
-#tools {
-     width: 20vw;
-
-     display: flex;
-     align-items: center;
-     justify-content: flex-start;
-}
-
-.tool {
-     width: 5vh;
-     height: 5vh;
-     outline: 0.5vh solid black;
-     margin-left: 2vw;
-
-     display: flex;
-}
-
 #logo {
-     width: 35vw;
+     width: 55vw;
      font-size: 4.5vh;
      font-weight: 600;
 

--- a/irek-nazmiev/index.html
+++ b/irek-nazmiev/index.html
@@ -27,12 +27,6 @@
 
      <body>
           <header id="header">
-               <div id="tools" class="header-block">
-                    <button class="tool" type="button" name="add-input"></button>
-                    <button class="tool" type="button" name="add-output"></button>
-                    <button class="tool" type="button" name="remove-wire"></button>
-               </div>
-
                <div id="logo" class="header-block">
                     <div>Drag&Code</div>
                </div>

--- a/irek-nazmiev/js/blocks-module.js
+++ b/irek-nazmiev/js/blocks-module.js
@@ -10,32 +10,35 @@ function addBlock(content) {
      var inputCons = createConWrapper("input"),
          outputCons = createConWrapper("output");
 
-     if (content == 'input') {
-          outputCons.appendChild(outputConnector);
-     } else if (content == 'output') {
-          inputCons.appendChild(inputConnector);
-     } else if (content == 'isSubstring') {
-          inputCons.appendChild(inputConnector);
-          outputCons.appendChild(outputConnector);
-     } else if (content == 'replace') {
-          appendChildren(inputCons, inputConnector, 3);
-          outputCons.appendChild(outputConnector);
-     } else {
-          appendChildren(inputCons, inputConnector, 2);
-          outputCons.appendChild(outputConnector);
-     }
-
      var block = createBlock();
+
+     var maxConId = 0;
+
+     if (content == 'input') {
+          appendChildren(0, 1);
+     } else if (content == 'output') {
+          appendChildren(1, 0);
+     } else if (content == 'isSubstring') {
+          appendChildren(1, 1);
+     } else if (content == 'replace') {
+          appendChildren(3, 1);
+     } else {
+          appendChildren(2, 1);
+     }
 
      fieldMovable.appendChild(block);
 
-     function appendChildren(parent, child, amount) {
-          var kid;
+     function appendChildren(inConAmount, outConAmount) {
 
-          for (i = 0; i < amount; i++) {
-               kid = child.cloneNode();
-               kid.textContent = i;
-               parent.appendChild(kid);
+          fillConWrapper(inputCons, inputConnector, inConAmount);
+          fillConWrapper(outputCons, outputConnector, outConAmount);
+
+          function fillConWrapper(conWrapper, connectorType, conAmount) {
+               for (i = 0; i < conAmount; i++) {
+                    var conClone = connectorType.cloneNode();
+                    conClone.textContent = block.name + "-" + maxConId++;
+                    conWrapper.appendChild(conClone);
+               }
           }
      }
 
@@ -51,7 +54,6 @@ function addBlock(content) {
 
           connector.setAttribute("onmousemove", "connect(this);");
           connector.name = "no-con";
-          connector.textContent = "0";
 
           return connector;
      }

--- a/irek-nazmiev/js/blocks-module.js
+++ b/irek-nazmiev/js/blocks-module.js
@@ -1,38 +1,91 @@
 var maxBlockId = 0;
 
 function addBlock(content) {
-     var inputConnectors = '<button class="in-con con"'
-               + ' onmousemove="connect(this);" name="no-con"></button>',
-         outputConnectors = '<button class="out-con con"'
-               +' onmousemove="connect(this);" name="no-con"></button>';
      var fieldMovable = document.getElementById('field-movable'),
          fieldMovableCoords = fieldMovable.getBoundingClientRect();
-     var block = document.createElement("button");
 
-     block.className = "block";
-     block.setAttribute("onmousemove", "moveBlock(this);");
-     block.style.left = -fieldMovableCoords.x +
-          document.body.clientWidth/2 + 'px';
-     block.style.top = -fieldMovableCoords.y +
-          document.body.clientHeight/2 + 'px';
-     block.name = maxBlockId++;
+     var inputConnector = createConnector("input"),
+         outputConnector = createConnector("output");
 
-     if (content == 'input')
-          inputConnectors = "";
-     else if (content == 'output')
-          outputConnectors = "";
-     else if (content == 'isSubstring')
-          inputConnectors = inputConnectors.repeat(1);
-     else if (content == 'replace')
-          inputConnectors = inputConnectors.repeat(3);
-     else
-          inputConnectors = inputConnectors.repeat(2);
+     var inputCons = createConWrapper("input"),
+         outputCons = createConWrapper("output");
 
-     block.innerHTML = content + '<div class="input-connectors connectors">'
-                     + inputConnectors
-                     + '</div><div class="output-connectors connectors">'
-                     + outputConnectors + '</div>';
-     field.children[0].appendChild(block);
+     if (content == 'input') {
+          outputCons.appendChild(outputConnector);
+     } else if (content == 'output') {
+          inputCons.appendChild(inputConnector);
+     } else if (content == 'isSubstring') {
+          inputCons.appendChild(inputConnector);
+          outputCons.appendChild(outputConnector);
+     } else if (content == 'replace') {
+          appendChildren(inputCons, inputConnector, 3);
+          outputCons.appendChild(outputConnector);
+     } else {
+          appendChildren(inputCons, inputConnector, 2);
+          outputCons.appendChild(outputConnector);
+     }
+
+     var block = createBlock();
+
+     fieldMovable.appendChild(block);
+
+     function appendChildren(parent, child, amount) {
+          var kid;
+
+          for (i = 0; i < amount; i++) {
+               kid = child.cloneNode();
+               kid.textContent = i;
+               parent.appendChild(kid);
+          }
+     }
+
+     function createConnector(type) {
+          var connector = document.createElement("button");
+
+          if (type == "input")
+               connector.className = "in-con con";
+          else if (type == "output")
+               connector.className = "out-con con";
+          else
+               alert("ERROR! Wrong type of connector!");
+
+          connector.setAttribute("onmousemove", "connect(this);");
+          connector.name = "no-con";
+          connector.textContent = "0";
+
+          return connector;
+     }
+
+     function createConWrapper(type) {
+          var conWrapper = document.createElement('div');
+
+          if (type == "input")
+               conWrapper.className = "input-connectors connectors";
+          else if (type == "output")
+               conWrapper.className = "output-connectors connectors";
+          else
+               alert("ERROR! Wrong type of connector!");
+
+          return conWrapper;
+     }
+
+     function createBlock() {
+          var block = document.createElement("button"),
+              screenWidth = document.body.clientWidth,
+              screenHeight = document.body.clientHeight;
+
+          block.textContent = content;
+          block.className = "block";
+          block.style.left = -fieldMovableCoords.x + screenWidth/2 + 'px';
+          block.style.top = -fieldMovableCoords.y + screenHeight/2 + 'px';
+          block.setAttribute("onmousemove", "moveBlock(this);");
+          block.name = maxBlockId++;
+
+          block.appendChild(inputCons);
+          block.appendChild(outputCons);
+
+          return block;
+     }
 }
 
 function openCloseSpoiler(block) {

--- a/irek-nazmiev/js/field-control-module.js
+++ b/irek-nazmiev/js/field-control-module.js
@@ -12,6 +12,7 @@ function moveBlock(block) {
                    trashCanWrapper =
                        document.getElementById("trash-can-wrapper"),
                    linesList = findConnectedLines(),
+                   connectors = findConnectedCons(linesList),
                    fieldMovableCoords = fieldMovable.getBoundingClientRect();
 
                isBusy = true;
@@ -105,8 +106,6 @@ function moveBlock(block) {
                     fieldMovable.style.zIndex = "unset";
 
                     if (isInTrashCan(x, y)) {
-                         var connectors = findConnectedCons();
-
                          linesList.forEach(function(line) {
                               line.item.remove();
                          });
@@ -140,24 +139,6 @@ function moveBlock(block) {
                     });
 
                     return linesList;
-               }
-
-               function findConnectedCons() {
-                    var consList = document.getElementsByClassName('con'),
-                        consIds = [];
-
-                    linesList.forEach(function(line) {
-                         conPairIds = line.item.textContent.split('|');
-                         consIds.push(conPairIds[0]);
-                         consIds.push(conPairIds[1]);
-                    });
-
-                    consList = [].slice.call(consList);
-                    consList = consList.filter(function(con) {
-                         return consIds.includes(con.textContent);
-                    });
-
-                    return consList;
                }
           }
 
@@ -300,25 +281,18 @@ function connect(headConnector) {
 
      headConnector.oncontextmenu = function(e) {
           if (headConnector.name == "con" && !isBusy) {
-               var connectionInfo = headConnector.textContent,
-                   linesList = findElemsByTextContent('line', connectionInfo),
-                   connectorsList = findElemsByTextContent('con', connectionInfo);
-
-               linesList[0].remove();
-               connectorsList.forEach(function(con) {
+               var linesList = document.getElementsByClassName('line');
+               linesList = [].slice.call(linesList);
+               linesList = linesList.filter(function(line) {
+                    return line.textContent.includes(headConnector.textContent);
+               });
+               consList = findConnectedCons(linesList);
+               linesList.forEach(function(line) {
+                    line.remove();
+               });
+               consList.forEach(function(con) {
                     con.name = "no-con";
                });
-          }
-
-          function findElemsByTextContent(className, textContent) {
-               var elemsList = document.getElementsByClassName(className);
-
-               elemsList = [].slice.call(elemsList);
-               elemsList = elemsList.filter(function(elem) {
-                    return elem.textContent == textContent;
-               });
-
-               return elemsList;
           }
      }
 
@@ -354,4 +328,22 @@ function connect(headConnector) {
      function getGrandParent(elem) {
           return elem.parentElement.parentElement;
      }
+}
+
+function findConnectedCons(linesList) {
+     var consList = document.getElementsByClassName('con'),
+         consIds = [];
+
+     linesList.forEach(function(line) {
+          conPairIds = line.textContent.split('|');
+          consIds.push(conPairIds[0]);
+          consIds.push(conPairIds[1]);
+     });
+
+     consList = [].slice.call(consList);
+     consList = consList.filter(function(con) {
+          return consIds.includes(con.textContent);
+     });
+
+     return consList;
 }

--- a/irek-nazmiev/js/field-control-module.js
+++ b/irek-nazmiev/js/field-control-module.js
@@ -263,9 +263,6 @@ function connect(headConnector) {
                                    "-" + getGrandParent(tailConnector).name +
                                    "|" + headConnector.textContent +
                                    "-" + tailConnector.textContent;
-                              // mark connectors the same as connected line was
-                              headConnector.textContent =
-                                   tailConnector.textContent = line.textContent;
 
                               // mark connected connectors
                               headConnector.name = tailConnector.name = 'con';

--- a/irek-nazmiev/js/field-control-module.js
+++ b/irek-nazmiev/js/field-control-module.js
@@ -259,10 +259,8 @@ function connect(headConnector) {
                          if (finishConnectingIsAvailable(tailConnector)) {
                               // mark the line with its head and tail blocks' ids
                               line.textContent =
-                                   getGrandParent(headConnector).name +
-                                   "-" + getGrandParent(tailConnector).name +
-                                   "|" + headConnector.textContent +
-                                   "-" + tailConnector.textContent;
+                                   headConnector.textContent + "|"
+                                        + tailConnector.textContent;
 
                               // mark connected connectors
                               headConnector.name = tailConnector.name = 'con';

--- a/irek-nazmiev/js/field-control-module.js
+++ b/irek-nazmiev/js/field-control-module.js
@@ -260,7 +260,9 @@ function connect(headConnector) {
                               // mark the line with its head and tail blocks' ids
                               line.textContent =
                                    getGrandParent(headConnector).name +
-                                        "-" + getGrandParent(tailConnector).name;
+                                   "-" + getGrandParent(tailConnector).name +
+                                   "|" + headConnector.textContent +
+                                   "-" + tailConnector.textContent;
                               // mark connectors the same as connected line was
                               headConnector.textContent =
                                    tailConnector.textContent = line.textContent;
@@ -311,7 +313,8 @@ function connect(headConnector) {
      }
 
      function startConnectingIsAvailable() {
-          return !isConnected(headConnector) && !isBusy;
+          return (!isConnected(headConnector) ||
+               headConnector.className == "out-con con") && !isBusy;
      }
 
      function finishConnectingIsAvailable(tailConnector) {

--- a/irek-nazmiev/js/field-control-module.js
+++ b/irek-nazmiev/js/field-control-module.js
@@ -303,7 +303,7 @@ function connect(headConnector) {
 
      function finishConnectingIsAvailable(tailConnector) {
           return isConnector(tailConnector) &&
-                    !isConnected(tailConnector) &&
+                    (!isConnected(tailConnector) || tailConnector.className == "out-con con") &&
                          connectorsHaveDifferentTypes() &&
                               !lieOnSameBlock();
 

--- a/irek-nazmiev/js/field-control-module.js
+++ b/irek-nazmiev/js/field-control-module.js
@@ -303,9 +303,10 @@ function connect(headConnector) {
 
      function finishConnectingIsAvailable(tailConnector) {
           return isConnector(tailConnector) &&
-                    (!isConnected(tailConnector) || tailConnector.className == "out-con con") &&
-                         connectorsHaveDifferentTypes() &&
-                              !lieOnSameBlock();
+                    (!isConnected(tailConnector) ||
+                         tailConnector.className == "out-con con") &&
+                              connectorsHaveDifferentTypes() &&
+                                   !lieOnSameBlock();
 
           function connectorsHaveDifferentTypes() {
                return headConnector.className != tailConnector.className;

--- a/irek-nazmiev/js/field-control-module.js
+++ b/irek-nazmiev/js/field-control-module.js
@@ -11,7 +11,7 @@ function moveBlock(block) {
                    fieldMovable = document.getElementById('field-movable'),
                    trashCanWrapper =
                        document.getElementById("trash-can-wrapper"),
-                   linesList = findConnectedElems('line'),
+                   linesList = findConnectedLines(),
                    fieldMovableCoords = fieldMovable.getBoundingClientRect();
 
                isBusy = true;
@@ -105,14 +105,13 @@ function moveBlock(block) {
                     fieldMovable.style.zIndex = "unset";
 
                     if (isInTrashCan(x, y)) {
-                         var connectors = findConnectedElems('con');
+                         var connectors = findConnectedCons();
 
                          linesList.forEach(function(line) {
                               line.item.remove();
                          });
                          connectors.forEach(function(connector) {
                               connector.name = "no-con";
-                              connector.textContent = "";
                          });
 
                          block.remove();
@@ -132,17 +131,33 @@ function moveBlock(block) {
                            y <= (trashCanCoords.top + trashCanCoords.height);
                }
 
-               function findConnectedElems(className) {
-                    var elemsList = document.getElementsByClassName(className);
+               function findConnectedLines() {
+                    var linesList = document.getElementsByClassName('line');
 
-                    // HTMLcollection to array
-                    elemsList = [].slice.call(elemsList);
-                    // leave in the list only elems connected to block
-                    elemsList = elemsList.filter(function(elem) {
-                         return elem.textContent.includes(block.name)
+                    linesList = [].slice.call(linesList);
+                    linesList = linesList.filter(function(line) {
+                         return line.textContent.includes(block.name + "-");
                     });
 
-                    return elemsList;
+                    return linesList;
+               }
+
+               function findConnectedCons() {
+                    var consList = document.getElementsByClassName('con'),
+                        consIds = [];
+
+                    linesList.forEach(function(line) {
+                         conPairIds = line.item.textContent.split('|');
+                         consIds.push(conPairIds[0]);
+                         consIds.push(conPairIds[1]);
+                    });
+
+                    consList = [].slice.call(consList);
+                    consList = consList.filter(function(con) {
+                         return consIds.includes(con.textContent);
+                    });
+
+                    return consList;
                }
           }
 

--- a/irek-nazmiev/js/field-control-module.js
+++ b/irek-nazmiev/js/field-control-module.js
@@ -2,18 +2,18 @@ var isBusy = false;
 
 // move the block related to field-movable or delete it with all connected wires
 function moveBlock(block) {
-     block.onmousedown = function(e) {       // start moving on first click
+     block.onmousedown = function(e) {       // start moving when holding left click btn
           if (blockIsAvailable()) {
                var x, y,
                    blockCoords = block.getBoundingClientRect(),
                    shiftX = e.pageX - blockCoords.left,
                    shiftY = e.pageY - blockCoords.top,
                    fieldMovable = document.getElementById('field-movable'),
+                   fieldMovableCoords = fieldMovable.getBoundingClientRect(),
                    trashCanWrapper =
                        document.getElementById("trash-can-wrapper"),
-                   linesList = findConnectedLines(),
-                   connectors = findConnectedCons(linesList),
-                   fieldMovableCoords = fieldMovable.getBoundingClientRect();
+                   linesList = findConnectedLines(block),
+                   connectors = findConnectedCons(linesList);
 
                isBusy = true;
                fieldMovable.style.zIndex = 1000;  // move block on foreground
@@ -80,17 +80,17 @@ function moveBlock(block) {
 
                     // update all lines connected to moving block
                     linesList.forEach(function(line) {
-                         if (lineIsConnected()) {    // head is here
+                         if (headConIsOnBlock(line, block)) {    // head is here
                               var x1 = e.pageX + line.shiftX1,
                                   y1 = e.pageY + line.shiftY1;
-                              updateLine(line.item, x1, y1, line.x2, line.y2)
+                              updateLine(line.item, x1, y1, line.x2, line.y2);
                          } else {
                               var x2 = e.pageX + line.shiftX2,
                                   y2 = e.pageY + line.shiftY2;
-                              updateLine(line.item, line.x1, line.y1, x2, y2)
+                              updateLine(line.item, line.x1, line.y1, x2, y2);
                          }
 
-                         function lineIsConnected() {
+                         function headConIsOnBlock(line, block) {
                               return line.item.textContent.split('-')[0]
                                    == block.name;
                          }
@@ -100,7 +100,7 @@ function moveBlock(block) {
                     y = e.pageY;
                }
 
-               block.onmouseup = function(e) {   // stop moving on second click
+               block.onmouseup = function(e) {   // stop moving when end holding left click btn
                     document.onmousemove = null;
                     block.onmouseup = null;
                     fieldMovable.style.zIndex = "unset";
@@ -130,7 +130,7 @@ function moveBlock(block) {
                            y <= (trashCanCoords.top + trashCanCoords.height);
                }
 
-               function findConnectedLines() {
+               function findConnectedLines(block) {
                     var linesList = document.getElementsByClassName('line');
 
                     linesList = [].slice.call(linesList);
@@ -336,8 +336,7 @@ function findConnectedCons(linesList) {
 
      linesList.forEach(function(line) {
           conPairIds = line.textContent.split('|');
-          consIds.push(conPairIds[0]);
-          consIds.push(conPairIds[1]);
+          consIds.push(conPairIds[0], conPairIds[1]);
      });
 
      consList = [].slice.call(consList);


### PR DESCRIPTION
Reformation of connectors' and lines' ids was succesfully made.
Now:
* each block has its own unique id ``n`` (there are no two blocks with the same id);
* each connector has its own id of format ``n-m`` where ``n`` is block's unique id on which this connector lies and ``m`` - connector's unique id (unique only inside its block - there are no connectors with the same id inside one block);
* each line has its own unique id of format ``n1-m1|n2-m2`` where ``n1-m1`` - first connector's id and ``n2-m2`` - second connector's id.